### PR TITLE
Fixed typo in usage instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,6 @@ Node version 6.5
 
 `npm install`
 
-`node benchmarking.js` to run benchmarks
+`node benchmark.js` to run benchmarks
 
 `mocha test.js` to run tests


### PR DESCRIPTION
Instructions listed `node benchmarking.js` as the command to run benchmarks.
The command should be `node benchmark.js`.

Modified the README to reflect the correct command.
Closes #1